### PR TITLE
Fix frontend Docker build by adding missing server.js

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,21 @@
-FROM node:18-alpine as build
+FROM node:18-alpine AS development
+WORKDIR /app
+
+RUN addgroup -g 1001 nodegroup && \
+    adduser -D -u 1001 -G nodegroup nodeuser && \
+    mkdir -p /app/node_modules && \
+    chown -R nodeuser:nodegroup /app
+
+USER nodeuser
+
+COPY --chown=nodeuser:nodegroup package*.json ./
+RUN npm ci && npm cache clean --force
+
+COPY --chown=nodeuser:nodegroup . .
+EXPOSE 3000
+CMD ["npm", "start"]
+
+FROM node:18-alpine AS build
 WORKDIR /app
 
 # Add node user and set permissions

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const path = require('path');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || '0.0.0.0';
+const BACKEND_URL = process.env.BACKEND_URL || 'http://backend:8080';
+const VOICE_SERVICE_URL = process.env.VOICE_SERVICE_URL || 'http://voice:8081';
+
+app.use(
+  '/api',
+  createProxyMiddleware({
+    target: BACKEND_URL,
+    changeOrigin: true,
+  })
+);
+
+app.use(
+  '/voice',
+  createProxyMiddleware({
+    target: VOICE_SERVICE_URL,
+    changeOrigin: true,
+  })
+);
+
+app.use(express.static(path.join(__dirname, 'build')));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'build', 'index.html'));
+});
+
+app.listen(PORT, HOST, () => {
+  console.log(`Frontend server listening on http://${HOST}:${PORT}`);
+});

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,0 +1,19 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+  app.use(
+    '/voice',
+    createProxyMiddleware({
+      target: process.env.VOICE_SERVICE_URL || 'http://voice:8081',
+      changeOrigin: true,
+    })
+  );
+
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: process.env.BACKEND_URL || 'http://backend:8080',
+      changeOrigin: true,
+    })
+  );
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The frontend Docker build was failing because `server.js` was referenced in the Dockerfile and `docker-compose.yml` (via the `fe86c34` "server fixes" commit) but the file was never added to the repository. The build fails at:

```
COPY --from=build /app/server.js /app/server.js
```

Additionally, `docker-compose.dev.yml` references `target: development` in the frontend Dockerfile, but no `development` stage existed.

## Solution

- **Added `frontend/server.js`**: Express server that serves the production React build and proxies `/api` → backend (`http://backend:8080`) and `/voice` → voice service (`http://voice:8081`)
- **Restored `frontend/src/setupProxy.js`**: Re-enables CRA dev-server proxying for `/api` and `/voice` during development
- **Added `development` stage to `frontend/Dockerfile`**: Fixes `docker-compose.dev.yml` builds that target the development stage

## Testing

- `npm run build` completes successfully
- `node server.js` serves the built app (HTTP 200 on `/`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1142d422-26a9-4100-8b7a-8bb1b5d625f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1142d422-26a9-4100-8b7a-8bb1b5d625f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

